### PR TITLE
remove the p5 context from the bindings

### DIFF
--- a/src/p5js_ffi.mjs
+++ b/src/p5js_ffi.mjs
@@ -52,23 +52,23 @@ export const startSketch = (config) => {
 };
 
 export function createCanvas(...args) {
-  p.createCanvas(...args);
+  return p.createCanvas(...args);
 }
 
 export function text(...args) {
-  p.text(...args);
+  return p.text(...args);
 }
 
 export function textFont(...args) {
-  p.textFont(...args);
+  return p.textFont(...args);
 }
 
 export function textFontFromString(...args) {
-  p.textFont(...args);
+  return p.textFont(...args);
 }
 
 export function textSize(...args) {
-  p.textSize(...args);
+  return p.textSize(...args);
 }
 
 export function textWidth(...args) {
@@ -76,63 +76,63 @@ export function textWidth(...args) {
 }
 
 export function background(...args) {
-  p.background(...args);
+  return p.background(...args);
 }
 
 export function ellipse(...args) {
-  p.ellipse(...args);
+  return p.ellipse(...args);
 }
 
 export function circle(...args) {
-  p.circle(...args);
+  return p.circle(...args);
 }
 
 export function rect(...args) {
-  p.rect(...args);
+  return p.rect(...args);
 }
 
 export function square(...args) {
-  p.square(...args);
+  return p.square(...args);
 }
 
 export function line(...args) {
-  p.line(...args);
+  return p.line(...args);
 }
 
 export function quad(...args) {
-  p.quad(...args);
+  return p.quad(...args);
 }
 
 export function image(...args) {
-  p.image(...args);
+  return p.image(...args);
 }
 
 export function fill(...args) {
-  p.fill(...args);
+  return p.fill(...args);
 }
 
 export function noFill(...args) {
-  p.noFill(...args);
+  return p.noFill(...args);
 }
 
 export function stroke(...args) {
-  p.stroke(...args);
+  return p.stroke(...args);
 }
 
 export function noStroke(...args) {
-  p.noStroke(...args);
+  return p.noStroke(...args);
 }
 
 export function strokeWeight(...args) {
-  p.strokeWeight(...args);
+  return p.strokeWeight(...args);
 }
 
 export function erase(...args) {
-  p.erase(...args);
+  return p.erase(...args);
 }
 
 export function noErase(...args) {
-  p.noErase(...args);
+  return p.noErase(...args);
 }
 
 export function loadImage(...args) {

--- a/src/p5js_ffi.mjs
+++ b/src/p5js_ffi.mjs
@@ -1,6 +1,6 @@
 import { is_some, unwrap } from "../gleam_stdlib/gleam/option.mjs";
 
-const p = null
+let p = null
 
 export const startSketch = (config) => {
   let model;

--- a/src/p5js_ffi.mjs
+++ b/src/p5js_ffi.mjs
@@ -1,21 +1,25 @@
 import { is_some, unwrap } from "../gleam_stdlib/gleam/option.mjs";
 
+const p = null
+
 export const startSketch = (config) => {
   let model;
   let assets;
-  new p5(function (p) {
+  new p5(function (p_) {
+    p = p_
+
     if (config.preload) {
       p.preload = function () {
-        assets = config.preload(p);
+        assets = config.preload();
       };
     }
 
     p.setup = function () {
-      model = config.init(p);
+      model = config.init();
     };
 
     p.draw = function () {
-      config.draw(p, model, assets);
+      config.draw(model, assets);
       if (is_some(config.on_tick)) {
         model = unwrap(config.on_tick)(model);
       }
@@ -47,114 +51,94 @@ export const startSketch = (config) => {
   });
 };
 
-export function createCanvas(p, ...args) {
+export function createCanvas(...args) {
   p.createCanvas(...args);
-  return p;
 }
 
-export function text(p, ...args) {
+export function text(...args) {
   p.text(...args);
-  return p;
 }
 
-export function textFont(p, ...args) {
+export function textFont(...args) {
   p.textFont(...args);
-  return p;
 }
 
-export function textFontFromString(p, ...args) {
+export function textFontFromString(...args) {
   p.textFont(...args);
-  return p;
 }
 
-export function textSize(p, ...args) {
+export function textSize(...args) {
   p.textSize(...args);
-  return p;
 }
 
-export function textWidth(p, ...args) {
+export function textWidth(...args) {
   return p.textWidth(...args);
 }
 
-export function background(p, ...args) {
+export function background(...args) {
   p.background(...args);
-  return p;
 }
 
-export function ellipse(p, ...args) {
+export function ellipse(...args) {
   p.ellipse(...args);
-  return p;
 }
 
-export function circle(p, ...args) {
+export function circle(...args) {
   p.circle(...args);
-  return p;
 }
 
-export function rect(p, ...args) {
+export function rect(...args) {
   p.rect(...args);
-  return p;
 }
 
-export function square(p, ...args) {
+export function square(...args) {
   p.square(...args);
-  return p;
 }
 
-export function line(p, ...args) {
+export function line(...args) {
   p.line(...args);
-  return p;
 }
 
-export function quad(p, ...args) {
+export function quad(...args) {
   p.quad(...args);
-  return p;
 }
 
-export function image(p, ...args) {
+export function image(...args) {
   p.image(...args);
-  return p;
 }
 
-export function fill(p, ...args) {
+export function fill(...args) {
   p.fill(...args);
-  return p;
 }
 
-export function noFill(p, ...args) {
+export function noFill(...args) {
   p.noFill(...args);
-  return p;
 }
 
-export function stroke(p, ...args) {
+export function stroke(...args) {
   p.stroke(...args);
-  return p;
 }
 
-export function noStroke(p, ...args) {
+export function noStroke(...args) {
   p.noStroke(...args);
-  return p;
 }
 
-export function strokeWeight(p, ...args) {
+export function strokeWeight(...args) {
   p.strokeWeight(...args);
-  return p;
 }
 
-export function erase(p, ...args) {
+export function erase(...args) {
   p.erase(...args);
-  return p;
 }
 
-export function noErase(p, ...args) {
+export function noErase(...args) {
   p.noErase(...args);
-  return p;
 }
 
-export function loadImage(p, ...args) {
+export function loadImage(...args) {
   return p.loadImage(...args);
 }
 
-export function loadFont(p, ...args) {
+export function loadFont(...args) {
   return p.loadFont(...args);
 }

--- a/src/p5js_gleam.gleam
+++ b/src/p5js_gleam.gleam
@@ -1,9 +1,6 @@
 import gleam/dict
 import gleam/option.{type Option}
 
-/// A reference to the P5js library. Primarily used to access the P5js APIs for drawing.
-pub type P5
-
 /// A reference to a P5js image object. Should be used by passing it to the P5js `image` function.
 pub type P5Image
 
@@ -50,9 +47,9 @@ pub fn get_image(assets: Assets, image_key: String) -> Result(P5Image, Nil) {
 pub opaque type SketchConfig(model, ignored) {
   BaseConfig(
     /// The init function takes a reference to the P5js library and returns the initial model. It should also create the canvas/do any P5 specific initialization.
-    init: fn(P5) -> model,
+    init: fn() -> model,
     /// The draw function takes a reference to the P5js library and the current model then renders it to the screen.
-    draw: fn(P5, model) -> ignored,
+    draw: fn(model) -> ignored,
     /// Called on every frame. on_tick functions take the current model, and return the updated model for the next frame.
     on_tick: Option(fn(model) -> model),
     /// Called whenever a key is pressed down. on_key_pressed functions take a string representing the key that was pressed and a keycode representing the raw key code of the pressed key, and the current model, and return the updated model.
@@ -66,11 +63,11 @@ pub opaque type SketchConfig(model, ignored) {
   )
   ConfigWithLoadingAssets(
     /// The preload function takes a reference to the P5js library and returns the assets that can be used by the sketch. This is needed to load external assets such as fonts and images prior to starting the sketch.
-    preload: fn(P5) -> Assets,
+    preload: fn() -> Assets,
     /// The init function takes a reference to the P5js library and returns the initial model. It should also create the canvas/do any P5 specific initialization.
-    init: fn(P5) -> model,
+    init: fn() -> model,
     /// The draw function takes a reference to the P5js library, any assets loaded during preload, and the current model then renders it to the screen.
-    draw: fn(P5, model, Assets) -> ignored,
+    draw: fn(model, Assets) -> ignored,
     /// Called on every frame. on_tick functions take the current model, and return the updated model for the next frame.
     on_tick: Option(fn(model) -> model),
     /// Called whenever a key is pressed down. on_key_pressed functions take a string representing the key that was pressed and a keycode representing the raw key code of the pressed key, and the current model, and return the updated model.
@@ -86,8 +83,8 @@ pub opaque type SketchConfig(model, ignored) {
 
 /// Creates a minimal sketch configuration.
 pub fn create_sketch(
-  init init: fn(P5) -> model,
-  draw draw: fn(P5, model) -> ignored,
+  init init: fn() -> model,
+  draw draw: fn(model) -> ignored,
 ) -> SketchConfig(model, ignored) {
   BaseConfig(
     init,
@@ -102,9 +99,9 @@ pub fn create_sketch(
 
 /// Creates a sketch configuration that supports preloading assets.
 pub fn create_sketch_with_preloading(
-  preload preload: fn(P5) -> Assets,
-  init init: fn(P5) -> model,
-  draw draw: fn(P5, model, Assets) -> ignored,
+  preload preload: fn() -> Assets,
+  init init: fn() -> model,
+  draw draw: fn(model, Assets) -> ignored,
 ) -> SketchConfig(model, ignored) {
   ConfigWithLoadingAssets(
     preload,

--- a/src/p5js_gleam/bindings.gleam
+++ b/src/p5js_gleam/bindings.gleam
@@ -1,89 +1,84 @@
-import p5js_gleam.{type P5, type P5Font, type P5Image, type SketchConfig}
+import p5js_gleam.{type P5Font, type P5Image, type SketchConfig}
 
-/// Starts a p5.js sketch with the given configuration.
-@external(javascript, "../p5js_ffi.mjs", "startSketch")
+/// Starts a Nil.js sketch with the given configuration.
+@external(javascript, "../Niljs_ffi.mjs", "startSketch")
 pub fn start_sketch(config: SketchConfig(model, ignored)) -> Nil
 
-/// A binding to the p5.js [`createCanvas`](https://p5js.org/reference/#/p5/createCanvas) function. Takes a p5 instance and the function's arguments and returns the p5 instance.
-@external(javascript, "../p5js_ffi.mjs", "createCanvas")
-pub fn create_canvas(p: P5, width: Float, height: Float) -> P5
+/// A binding to the Nil.js [`createCanvas`](https://Niljs.org/reference/#/Nil/createCanvas) function. Takes a Nil instance and the function's arguments and returns the Nil instance.
+@external(javascript, "../Niljs_ffi.mjs", "createCanvas")
+pub fn create_canvas(width: Float, height: Float) -> Nil
 
-/// A binding to the p5.js [`text`](https://p5js.org/reference/#/p5/text) function. Takes a p5 instance and the function's arguments and returns the p5 instance.
-@external(javascript, "../p5js_ffi.mjs", "text")
+/// A binding to the Nil.js [`text`](https://Niljs.org/reference/#/Nil/text) function. Takes a Nil instance and the function's arguments and returns the Nil instance.
+@external(javascript, "../Niljs_ffi.mjs", "text")
 pub fn text(
-  p: P5,
+  p: Nil,
   text: String,
   bottom_corner_x: Float,
   bottom_corner_y: Float,
-) -> P5
+) -> Nil
 
-/// A binding to the p5.js [`textFont`](https://p5js.org/reference/#/p5/textFont) function. Takes a p5 instance and the function's arguments and returns the p5 instance.
-@external(javascript, "../p5js_ffi.mjs", "textFont")
-pub fn text_font(p: P5, font: P5Font) -> P5
+/// A binding to the Nil.js [`textFont`](https://Niljs.org/reference/#/Nil/textFont) function. Takes a Nil instance and the function's arguments and returns the Nil instance.
+@external(javascript, "../Niljs_ffi.mjs", "textFont")
+pub fn text_font(font: P5Font) -> Nil
 
-/// A binding to the p5.js [`textFont`](https://p5js.org/reference/#/p5/textFont) function. Takes a p5 instance and the function's arguments and returns the p5 instance.
-@external(javascript, "../p5js_ffi.mjs", "textFontFromString")
-pub fn text_font_from_string(p: P5, font: String) -> P5
+/// A binding to the Nil.js [`textFont`](https://Niljs.org/reference/#/Nil/textFont) function. Takes a Nil instance and the function's arguments and returns the Nil instance.
+@external(javascript, "../Niljs_ffi.mjs", "textFontFromString")
+pub fn text_font_from_string(font: String) -> Nil
 
-/// A binding to the p5.js [`textSize`](https://p5js.org/reference/#/p5/textSize) function. Takes a p5 instance and the function's arguments and returns the p5 instance.
-@external(javascript, "../p5js_ffi.mjs", "textSize")
-pub fn text_size(p: P5, size: Int) -> P5
+/// A binding to the Nil.js [`textSize`](https://Niljs.org/reference/#/Nil/textSize) function. Takes a Nil instance and the function's arguments and returns the Nil instance.
+@external(javascript, "../Niljs_ffi.mjs", "textSize")
+pub fn text_size(size: Int) -> Nil
 
-/// A binding to the p5.js [`textWidth`](https://p5js.org/reference/#/p5/textWidth) function. Takes a p5 instance and the function's arguments and returns the p5 instance.
-@external(javascript, "../p5js_ffi.mjs", "textWidth")
-pub fn text_width(p: P5, text: String) -> Float
+/// A binding to the Nil.js [`textWidth`](https://Niljs.org/reference/#/Nil/textWidth) function. Takes a Nil instance and the function's arguments and returns the Nil instance.
+@external(javascript, "../Niljs_ffi.mjs", "textWidth")
+pub fn text_width(text: String) -> Float
 
-/// A binding to the p5.js [`background`](https://p5js.org/reference/#/p5/background) function. Takes a p5 instance and the function's arguments and returns the p5 instance.
-@external(javascript, "../p5js_ffi.mjs", "background")
-pub fn background(p: P5, color: String) -> P5
+/// A binding to the Nil.js [`background`](https://Niljs.org/reference/#/Nil/background) function. Takes a Nil instance and the function's arguments and returns the Nil instance.
+@external(javascript, "../Niljs_ffi.mjs", "background")
+pub fn background(color: String) -> Nil
 
-/// A binding to the p5.js [`ellipse`](https://p5js.org/reference/#/p5/ellipse) function. Takes a p5 instance and the function's arguments and returns the p5 instance.
-@external(javascript, "../p5js_ffi.mjs", "ellipse")
+/// A binding to the Nil.js [`ellipse`](https://Niljs.org/reference/#/Nil/ellipse) function. Takes a Nil instance and the function's arguments and returns the Nil instance.
+@external(javascript, "../Niljs_ffi.mjs", "ellipse")
 pub fn ellipse(
-  p: P5,
   x_center: Float,
   y_center: Float,
   width: Float,
   height: Float,
-) -> P5
+) -> Nil
 
-/// A binding to the p5.js [`circle`](https://p5js.org/reference/#/p5/circle) function. Takes a p5 instance and the function's arguments and returns the p5 instance.
-@external(javascript, "../p5js_ffi.mjs", "circle")
-pub fn circle(p: P5, x_center: Float, y_center: Float, diameter: Float) -> P5
+/// A binding to the Nil.js [`circle`](https://Niljs.org/reference/#/Nil/circle) function. Takes a Nil instance and the function's arguments and returns the Nil instance.
+@external(javascript, "../Niljs_ffi.mjs", "circle")
+pub fn circle(x_center: Float, y_center: Float, diameter: Float) -> Nil
 
-/// A binding to the p5.js [`rect`](https://p5js.org/reference/#/p5/rect) function. Takes a p5 instance and the function's arguments and returns the p5 instance.
-@external(javascript, "../p5js_ffi.mjs", "rect")
+/// A binding to the Nil.js [`rect`](https://Niljs.org/reference/#/Nil/rect) function. Takes a Nil instance and the function's arguments and returns the Nil instance.
+@external(javascript, "../Niljs_ffi.mjs", "rect")
 pub fn rect(
-  p: P5,
   top_left_x: Float,
   top_left_y: Float,
   width: Float,
   height: Float,
-) -> P5
+) -> Nil
 
-/// A binding to the p5.js [`square`](https://p5js.org/reference/#/p5/square) function. Takes a p5 instance and the function's arguments and returns the p5 instance.
-@external(javascript, "../p5js_ffi.mjs", "square")
+/// A binding to the Nil.js [`square`](https://Niljs.org/reference/#/Nil/square) function. Takes a Nil instance and the function's arguments and returns the Nil instance.
+@external(javascript, "../Niljs_ffi.mjs", "square")
 pub fn square(
-  p: P5,
   top_left_x: Float,
   top_left_y: Float,
   side_length: Float,
-) -> P5
+) -> Nil
 
-/// A binding to the p5.js [`line`](https://p5js.org/reference/#/p5/line) function. Takes a p5 instance and the function's arguments and returns the p5 instance.
-@external(javascript, "../p5js_ffi.mjs", "line")
+/// A binding to the Nil.js [`line`](https://Niljs.org/reference/#/Nil/line) function. Takes a Nil instance and the function's arguments and returns the Nil instance.
+@external(javascript, "../Niljs_ffi.mjs", "line")
 pub fn line(
-  p: P5,
   point1_x: Float,
   point1_y: Float,
   point2_x: Float,
   point2_y: Float,
-) -> P5
+) -> Nil
 
-/// A binding to the p5.js [`quad`](https://p5js.org/reference/#/p5/quad) function. Takes a p5 instance and the function's arguments and returns the p5 instance.
-@external(javascript, "../p5js_ffi.mjs", "quad")
+/// A binding to the Nil.js [`quad`](https://Niljs.org/reference/#/Nil/quad) function. Takes a Nil instance and the function's arguments and returns the Nil instance.
+@external(javascript, "../Niljs_ffi.mjs", "quad")
 pub fn quad(
-  p: P5,
   p1_x: Float,
   p1_y: Float,
   p2_x: Float,
@@ -92,51 +87,50 @@ pub fn quad(
   p3_y: Float,
   p4_x: Float,
   p4_y: Float,
-) -> P5
+) -> Nil
 
-/// A binding to the p5.js [`image`](https://p5js.org/reference/#/p5/image) function. Takes a p5 instance and the function's arguments and returns the p5 instance.
-@external(javascript, "../p5js_ffi.mjs", "image")
+/// A binding to the Nil.js [`image`](https://Niljs.org/reference/#/Nil/image) function. Takes a Nil instance and the function's arguments and returns the Nil instance.
+@external(javascript, "../Niljs_ffi.mjs", "image")
 pub fn image(
-  p: P5,
   image: P5Image,
   top_left_x: Float,
   top_left_y: Float,
   width: Float,
   height: Float,
-) -> P5
+) -> Nil
 
-/// A binding to the p5.js [`fill`](https://p5js.org/reference/#/p5/fill) function. Takes a p5 instance and the function's arguments and returns the p5 instance.
-@external(javascript, "../p5js_ffi.mjs", "fill")
-pub fn fill(p: P5, color_hex: String) -> P5
+/// A binding to the Nil.js [`fill`](https://Niljs.org/reference/#/Nil/fill) function. Takes a Nil instance and the function's arguments and returns the Nil instance.
+@external(javascript, "../Niljs_ffi.mjs", "fill")
+pub fn fill(color_hex: String) -> Nil
 
-/// A binding to the p5.js [`noFill`](https://p5js.org/reference/#/p5/noFill) function. Takes a p5 instance and the function's arguments and returns the p5 instance.
-@external(javascript, "../p5js_ffi.mjs", "noFill")
-pub fn no_fill(p: P5) -> P5
+/// A binding to the Nil.js [`noFill`](https://Niljs.org/reference/#/Nil/noFill) function. Takes a Nil instance and the function's arguments and returns the Nil instance.
+@external(javascript, "../Niljs_ffi.mjs", "noFill")
+pub fn no_fill() -> Nil
 
-/// A binding to the p5.js [`stroke`](https://p5js.org/reference/#/p5/stroke) function. Takes a p5 instance and the function's arguments and returns the p5 instance.
-@external(javascript, "../p5js_ffi.mjs", "stroke")
-pub fn stroke(p: P5, color_hex: String) -> P5
+/// A binding to the Nil.js [`stroke`](https://Niljs.org/reference/#/Nil/stroke) function. Takes a Nil instance and the function's arguments and returns the Nil instance.
+@external(javascript, "../Niljs_ffi.mjs", "stroke")
+pub fn stroke(color_hex: String) -> Nil
 
-/// A binding to the p5.js [`noStroke`](https://p5js.org/reference/#/p5/noStroke) function. Takes a p5 instance and the function's arguments and returns the p5 instance.
-@external(javascript, "../p5js_ffi.mjs", "noStroke")
-pub fn no_stroke(p: P5) -> P5
+/// A binding to the Nil.js [`noStroke`](https://Niljs.org/reference/#/Nil/noStroke) function. Takes a Nil instance and the function's arguments and returns the Nil instance.
+@external(javascript, "../Niljs_ffi.mjs", "noStroke")
+pub fn no_stroke() -> Nil
 
-/// A binding to the p5.js [`strokeWeight`](https://p5js.org/reference/#/p5/strokeWeight) function. Takes a p5 instance and the function's arguments and returns the p5 instance.
-@external(javascript, "../p5js_ffi.mjs", "strokeWeight")
-pub fn stroke_weight(p: P5, weight: Int) -> P5
+/// A binding to the Nil.js [`strokeWeight`](https://Niljs.org/reference/#/Nil/strokeWeight) function. Takes a Nil instance and the function's arguments and returns the Nil instance.
+@external(javascript, "../Niljs_ffi.mjs", "strokeWeight")
+pub fn stroke_weight(weight: Int) -> Nil
 
-/// A binding to the p5.js [`erase`](https://p5js.org/reference/#/p5/erase) function. Takes a p5 instance and the function's arguments and returns the p5 instance.
-@external(javascript, "../p5js_ffi.mjs", "erase")
-pub fn erase(p: P5, strength: Int, edge_strength: Int) -> P5
+/// A binding to the Nil.js [`erase`](https://Niljs.org/reference/#/Nil/erase) function. Takes a Nil instance and the function's arguments and returns the Nil instance.
+@external(javascript, "../Niljs_ffi.mjs", "erase")
+pub fn erase(strength: Int, edge_strength: Int) -> Nil
 
-/// A binding to the p5.js [`noErase`](https://p5js.org/reference/#/p5/noErase) function. Takes a p5 instance and the function's arguments and returns the p5 instance.
-@external(javascript, "../p5js_ffi.mjs", "noErase")
-pub fn no_erase(p: P5) -> P5
+/// A binding to the Nil.js [`noErase`](https://Niljs.org/reference/#/Nil/noErase) function. Takes a Nil instance and the function's arguments and returns the Nil instance.
+@external(javascript, "../Niljs_ffi.mjs", "noErase")
+pub fn no_erase() -> Nil
 
-/// A binding to the p5.js [`loadImage`](https://p5js.org/reference/#/p5/loadImage) function. Takes a p5 instance and the function's arguments and returns the p5 instance.
-@external(javascript, "../p5js_ffi.mjs", "loadImage")
-pub fn load_image(p: P5, path: String) -> P5Image
+/// A binding to the Nil.js [`loadImage`](https://Niljs.org/reference/#/Nil/loadImage) function. Takes a Nil instance and the function's arguments and returns the Nil instance.
+@external(javascript, "../Niljs_ffi.mjs", "loadImage")
+pub fn load_image(path: String) -> P5Image
 
-/// A binding to the p5.js [`loadFont`](https://p5js.org/reference/#/p5/loadFont) function. Takes a p5 instance and the function's arguments and returns the p5 instance.
-@external(javascript, "../p5js_ffi.mjs", "loadFont")
-pub fn load_font(p: P5, path: String) -> P5Font
+/// A binding to the Nil.js [`loadFont`](https://Niljs.org/reference/#/Nil/loadFont) function. Takes a Nil instance and the function's arguments and returns the Nil instance.
+@external(javascript, "../Niljs_ffi.mjs", "loadFont")
+pub fn load_font(path: String) -> P5Font


### PR DESCRIPTION
Makes the `p` variable module scoped. There is no longer a need to pass the p5 context to the FFI functions.

Pros
* Simpler to use

Cons
* P5js can no longer be used for multiple canvas